### PR TITLE
adv_fn! macro cleanup

### DIFF
--- a/benches/abs_normal.rs
+++ b/benches/abs_normal.rs
@@ -4,15 +4,15 @@ extern crate advantage as adv;
 extern crate test;
 
 use adv::prelude::*;
+use adv::Float;
 use test::Bencher;
 
-adv_fn! {
-    fn test_function(input: Vec<Scalar>) -> Scalar {
-        input.iter()
-            .map(|x| x.max(Scalar::zero()))
-            .map(|x| x.min(Scalar::one()))
-            .fold(Scalar::zero(), |a, b| a.max(b))
-    }
+fn test_function<T: Float>(input: Vec<T>) -> T {
+    input
+        .iter()
+        .map(|x| x.max(T::zero()))
+        .map(|x| x.min(T::one()))
+        .fold(T::zero(), |a, b| a.max(b))
 }
 
 fn test_function_tape() -> impl adv::Tape {

--- a/examples/perceptron.rs
+++ b/examples/perceptron.rs
@@ -1,76 +1,71 @@
 extern crate advantage as adv;
 
-use adv::adv_fn;
 use adv::prelude::*;
+use adv::Float;
 
-adv_fn! {
-    /// Sigmoid function
-    fn sigmoid(x: Scalar) -> Scalar {
-        let x_exp = x.exp();
-        x_exp / (x_exp + 1.0)
-    }
+/// Sigmoid function
+fn sigmoid<T: Float>(x: T) -> T {
+    let x_exp = x.exp();
+    x_exp / (x_exp + T::one())
 }
 
-adv_fn! {
-    /// A simple multilayer perceptron with 2 input neuron, 2 hidden neurons and 1 output neuron
-    fn multilayer_perceptron(
-        inputs: &[f64],
-        weights1: &[Scalar],
-        biases1: &[Scalar],
-        weights2: &[Scalar],
-        biases2: &[Scalar],
-    ) -> Scalar
-    {
-        assert_eq!(inputs.len(), 2);
-        assert_eq!(weights1.len(), 4);
-        assert_eq!(biases1.len(), 2);
-        assert_eq!(weights2.len(), 2);
-        assert_eq!(biases2.len(), 1);
+/// A simple multilayer perceptron with 2 input neuron, 2 hidden neurons and 1 output neuron
+fn multilayer_perceptron<T: Float>(
+    inputs: &[f64],
+    weights1: &[T],
+    biases1: &[T],
+    weights2: &[T],
+    biases2: &[T],
+) -> T {
+    assert_eq!(inputs.len(), 2);
+    assert_eq!(weights1.len(), 4);
+    assert_eq!(biases1.len(), 2);
+    assert_eq!(weights2.len(), 2);
+    assert_eq!(biases2.len(), 1);
 
-        let hidden1 = sigmoid(inputs[0] * weights1[0] + inputs[1] * weights1[1] + biases1[0]);
-        let hidden2 = sigmoid(inputs[0] * weights1[2] + inputs[1] * weights1[3] + biases1[1]);
-        sigmoid(hidden1 * weights2[0] + hidden2 * weights2[1] + biases2[0])
-    }
+    let input0 = T::from(inputs[0]).unwrap();
+    let input1 = T::from(inputs[1]).unwrap();
+    let hidden1 = sigmoid(input0 * weights1[0] + input1 * weights1[1] + biases1[0]);
+    let hidden2 = sigmoid(input0 * weights1[2] + input1 * weights1[3] + biases1[1]);
+    sigmoid(hidden1 * weights2[0] + hidden2 * weights2[1] + biases2[0])
 }
 
-adv_fn! {
-    /// Sum of square differences between the network and a xor-gate
-    fn xor_error(weights1: &[Scalar], biases1: &[Scalar], weights2: &[Scalar], biases2: &[Scalar]) -> Scalar {
-        assert_eq!(weights1.len(), 4);
-        assert_eq!(biases1.len(), 2);
-        assert_eq!(weights2.len(), 2);
-        assert_eq!(biases2.len(), 1);
+/// Sum of square differences between the network and a xor-gate
+fn xor_error<T: Float>(weights1: &[T], biases1: &[T], weights2: &[T], biases2: &[T]) -> T {
+    assert_eq!(weights1.len(), 4);
+    assert_eq!(biases1.len(), 2);
+    assert_eq!(weights2.len(), 2);
+    assert_eq!(biases2.len(), 1);
 
-        let error1 = {
-            let input = [0.0, 0.0];
-            let expected = 0.0;
-            let actual = multilayer_perceptron(&input, weights1, biases1, weights2, biases2);
-            (actual - expected) * (actual - expected)
-        };
+    let error1 = {
+        let input = [0.0, 0.0];
+        let expected = T::zero();
+        let actual = multilayer_perceptron(&input, weights1, biases1, weights2, biases2);
+        (actual - expected) * (actual - expected)
+    };
 
-        let error2 = {
-            let input = [0.0, 1.0];
-            let expected = 1.0;
-            let actual = multilayer_perceptron(&input, weights1, biases1, weights2, biases2);
-            (actual - expected) * (actual - expected)
-        };
+    let error2 = {
+        let input = [0.0, 1.0];
+        let expected = T::one();
+        let actual = multilayer_perceptron(&input, weights1, biases1, weights2, biases2);
+        (actual - expected) * (actual - expected)
+    };
 
-        let error3 = {
-            let input = [1.0, 0.0];
-            let expected = 1.0;
-            let actual = multilayer_perceptron(&input, weights1, biases1, weights2, biases2);
-            (actual - expected) * (actual - expected)
-        };
+    let error3 = {
+        let input = [1.0, 0.0];
+        let expected = T::one();
+        let actual = multilayer_perceptron(&input, weights1, biases1, weights2, biases2);
+        (actual - expected) * (actual - expected)
+    };
 
-        let error4 = {
-            let input = [1.0, 1.0];
-            let expected = 0.0;
-            let actual = multilayer_perceptron(&input, weights1, biases1, weights2, biases2);
-            (actual - expected) * (actual - expected)
-        };
+    let error4 = {
+        let input = [1.0, 1.0];
+        let expected = T::zero();
+        let actual = multilayer_perceptron(&input, weights1, biases1, weights2, biases2);
+        (actual - expected) * (actual - expected)
+    };
 
-        error1 + error2 + error3 + error4
-    }
+    error1 + error2 + error3 + error4
 }
 
 fn gradient(tape: &mut dyn adv::Tape, params: &adv::DVector<f64>) -> adv::DMatrix<f64> {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -32,21 +32,6 @@ macro_rules! adv_fn {
             }
         }
     };
-    {
-        $(#[$attr:meta])*
-        $vis:vis fn $func_name:ident ( $($arg_name:ident : $arg_type:ty $(,)?)* ) $(-> $return_type:ty)? {
-            $($tt:tt)*
-        }
-    } => {
-        $(#[$attr])*
-        $vis fn $func_name<Scalar> ( $($arg_name : $arg_type ),* ) $(-> $return_type)?
-        where
-            Scalar: core::fmt::Debug + $crate::Scalar<f64>,
-            f64: $crate::Arithmetic<Scalar, Scalar>,
-        {
-            $($tt)*
-        }
-    };
 }
 
 /// Get the associated metadata for a function defined with `adv_fn!`

--- a/src/tape.rs
+++ b/src/tape.rs
@@ -112,6 +112,7 @@ mod tests {
     use super::*;
 
     adv_fn! {
+        /// Function using all arithmetic operations
         fn all_arithmetic_test_func(x: [[1]]) -> [[1]] {
             let x = x[0];
             let v1 = x + x - x * x / x;
@@ -123,6 +124,7 @@ mod tests {
         }
     }
 
+    /// `all_arithmetic_test_func` can be replayed from tape with different inputs
     #[test]
     fn zero_order_arithmetic() {
         let mut tape = adv_fn_obj!(all_arithmetic_test_func).tape(&DVector::zeros(1));
@@ -132,6 +134,7 @@ mod tests {
         assert!((actual - expected).abs() < std::f64::EPSILON);
     }
 
+    /// Forward-mode AD works on `all_arithmetic_test_func`
     #[test]
     fn first_order_forward_arithmetic() {
         let tape = adv_fn_obj!(all_arithmetic_test_func).tape(&DVector::from_element(1, 3.0));
@@ -139,6 +142,7 @@ mod tests {
         assert!((dy[0] - 1.0).abs() < std::f64::EPSILON);
     }
 
+    /// Reverse-mode AD works on `all_arithmetic_test_func`
     #[test]
     fn first_order_reverse_arithmetic() {
         let tape = adv_fn_obj!(all_arithmetic_test_func).tape(&DVector::from_element(1, 3.0));
@@ -146,6 +150,7 @@ mod tests {
         assert!((xbar[0] - 1.0).abs() < std::f64::EPSILON);
     }
 
+    /// Test forward-mode and reverse-mode on a single unary function
     macro_rules! unary_test_case {
         ($func:ident, $start:expr, $end:expr, $num_tests:expr, $dy:expr) => {{
             const EPS: f64 = 1e-5;
@@ -181,6 +186,7 @@ mod tests {
         };
     }
 
+    /// Forward-mode and reverse-mode work on nonlinear unary functions
     #[test]
     #[allow(clippy::redundant_closure_call)]
     #[allow(clippy::cognitive_complexity)]


### PR DESCRIPTION
Remove variant of `adv_fn!` that is incompatible with `adv_fn_obj!`.

An example of this is
```rust
adv_fn! {
    fn foo(a: Scalar) -> Scalar {
        ...
    }
}
```
which contains the magic type `Scalar`.

Instead of this we can write
```rust
fn foo<T: Float>(a: T) -> T {
    ...
}
```
which is much more explicit and can be adapted to more situations.